### PR TITLE
Fix schema bug, update .gitignore, and correct README typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+
+.DS_Store

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -349,7 +349,7 @@ respectively.
 To generate the guidelines, please run the following command:
 ```bash
 cd guideline_generation
-python synthesize_guidelines/create_dictionaries.py --dataset_anem <dataset_name>
+python synthesize_guidelines/create_dictionaries.py --dataset_name <dataset_name>
 python prompting/prompt_llms.py #generates guidelines P, PN, PS
 python prompting/prompt_llm_adv_guidelines.py #generates Int- guidelines
 cd .. # to navigate to home directory

--- a/code_schema_generation/generate_schema.py
+++ b/code_schema_generation/generate_schema.py
@@ -80,8 +80,8 @@ def process_dataset(dataset):
             if event_type not in cur_schema:
                 cur_schema[event_type] = set()
             # get the attributes
-            arguments = [x.replace("-", "_") for x in event["arguments"]]
-            for argument in arguments:
+            # arguments = [x.replace("-", "_") for x in event["arguments"]]
+            for argument in event["arguments"]:
                 role = argument["role"].lower().replace("-", "_")
                 cur_schema[event_type].add(role)
             cur_schema[event_type].add("mention")


### PR DESCRIPTION
### Summary of Fixes
This PR addresses the following issues:

1. Fixes a schema processing bug in `generate_schema.py`
   - Replaced incorrect use of `.replace()` on a dict object with proper key access (`argument["role"]`).
   - Ensures role names with hyphens are normalized using `replace("-", "_")`.

2. Corrects a typo in the README
   - Changed `--dataset_anem` to `--dataset_name`.

3. Adds `.DS_Store` to `.gitignore`  
   - To prevent macOS system files from being tracked.

### Context
These changes respond to [Issue #1](https://github.com/Ziyu-Yao-NLP-Lab/PyCode-TextEE/issues/1) and improve usability for other researchers trying to run the repo.