### PR TITLE
Fix eval-time generation: left-pad and pass attention_mask (addresses #4)

### DIFF
--- a/instruction_tuning_with_guidelines_ACL_2025/scripts/7_LLaMA_Code/LLaMATrainer.py
+++ b/instruction_tuning_with_guidelines_ACL_2025/scripts/7_LLaMA_Code/LLaMATrainer.py
@@ -21,6 +21,13 @@ class LLaMATrainer(SFTTrainer):
         logger.info("Running evaluation loop...")
         FastLanguageModel.for_inference(self.model) # Enable native 2x faster inference
 
+        # Decoder-only models must be LEFT-padded for batched generation. The eval
+        # collator otherwise right-pads (this is the "right-padding was detected"
+        # warning), which makes generate() continue from pad positions and emit
+        # garbage that no longer matches the expected `[Event(...)]` output format.
+        original_padding_side = self.tokenizer.padding_side
+        self.tokenizer.padding_side = "left"
+
         eval_dataset = eval_dataset if eval_dataset is not None else self.eval_dataset
         outputs = []
         all_decoder_ids = []
@@ -38,9 +45,11 @@ class LLaMATrainer(SFTTrainer):
         with torch.no_grad():
             for batch_idx, eval_set in tqdm(enumerate(eval_loader), total=len(eval_loader), desc=f"Hold on, :D, doing {metric_key_prefix} ..."):
                 # Prepare batched input_ids
-                input_ids = eval_set["input_ids"]#torch.tensor([item['input_ids'] for item in eval_set]).to(self.model.device)
+                input_ids = eval_set["input_ids"].to(self.model.device)
+                # Pass the attention mask so padded positions are ignored during generation.
+                attention_mask = eval_set["attention_mask"].to(self.model.device)
                 # Generate outputs for the entire batch
-                decoder_ids = self.model.generate(input_ids,max_new_tokens=250, pad_token_id = self.tokenizer.pad_token_id)
+                decoder_ids = self.model.generate(input_ids=input_ids, attention_mask=attention_mask, max_new_tokens=250, pad_token_id = self.tokenizer.pad_token_id)
                 # Decode all outputs in the batch
                 decoded_output = self.tokenizer.batch_decode(decoder_ids, skip_special_tokens=True)
                 # Decode the input sentences in the batch
@@ -79,5 +88,8 @@ class LLaMATrainer(SFTTrainer):
         del all_decoder_ids
         torch.cuda.empty_cache()
         gc.collect()
+        # Restore the original padding side so training (loss computed over
+        # right-padded batches) is unaffected by the left-padding used for generation.
+        self.tokenizer.padding_side = original_padding_side
         FastLanguageModel.for_training(self.model)
         return output_metrics

--- a/training_scripts/LLaMATrainer.py
+++ b/training_scripts/LLaMATrainer.py
@@ -21,6 +21,13 @@ class LLaMATrainer(SFTTrainer):
         logger.info("Running evaluation loop...")
         FastLanguageModel.for_inference(self.model) # Enable native 2x faster inference
 
+        # Decoder-only models must be LEFT-padded for batched generation. The eval
+        # collator otherwise right-pads (this is the "right-padding was detected"
+        # warning), which makes generate() continue from pad positions and emit
+        # garbage that no longer matches the expected `[Event(...)]` output format.
+        original_padding_side = self.tokenizer.padding_side
+        self.tokenizer.padding_side = "left"
+
         eval_dataset = eval_dataset if eval_dataset is not None else self.eval_dataset
         outputs = []
         all_decoder_ids = []
@@ -38,9 +45,11 @@ class LLaMATrainer(SFTTrainer):
         with torch.no_grad():
             for batch_idx, eval_set in tqdm(enumerate(eval_loader), total=len(eval_loader), desc=f"Hold on, :D, doing {metric_key_prefix} ..."):
                 # Prepare batched input_ids
-                input_ids = eval_set["input_ids"]#torch.tensor([item['input_ids'] for item in eval_set]).to(self.model.device)
+                input_ids = eval_set["input_ids"].to(self.model.device)
+                # Pass the attention mask so padded positions are ignored during generation.
+                attention_mask = eval_set["attention_mask"].to(self.model.device)
                 # Generate outputs for the entire batch
-                decoder_ids = self.model.generate(input_ids,max_new_tokens=250, pad_token_id = self.tokenizer.pad_token_id)
+                decoder_ids = self.model.generate(input_ids=input_ids, attention_mask=attention_mask, max_new_tokens=250, pad_token_id = self.tokenizer.pad_token_id)
                 # Decode all outputs in the batch
                 decoded_output = self.tokenizer.batch_decode(decoder_ids, skip_special_tokens=True)
                 # Decode the input sentences in the batch
@@ -79,5 +88,8 @@ class LLaMATrainer(SFTTrainer):
         del all_decoder_ids
         torch.cuda.empty_cache()
         gc.collect()
+        # Restore the original padding side so training (loss computed over
+        # right-padded batches) is unaffected by the left-padding used for generation.
+        self.tokenizer.padding_side = original_padding_side
         FastLanguageModel.for_training(self.model)
         return output_metrics


### PR DESCRIPTION
## Summary
Restores correct batched generation in `LLaMATrainer.evaluate()`. The eval loop generated from
**right-padded** batches and without an attention mask, which on a decoder-only model (Llama-3)
produces the `right-padding was detected ... set padding_side='left'` warning reported in #4 and
degrades generated text so it no longer matches the expected `[Event(...)]` output format.

## Root cause
In `LLaMATrainer.evaluate()`:
- the eval collator pads on the right, but decoder-only models must be **left-padded** for
  batched `generate()`, otherwise generation continues from pad positions;
- `model.generate(input_ids, ...)` was called **without** an `attention_mask`, so pad tokens
  were attended to.

## Fix
- Set `tokenizer.padding_side = "left"` for the eval/generation loop and restore the original
  side afterward, so training (loss over right-padded batches) is unaffected.
- Pass the collated `attention_mask` to `generate()` and move inputs to the model device.

Applied to both copies of the trainer:
- `training_scripts/LLaMATrainer.py`
- `instruction_tuning_with_guidelines_ACL_2025/scripts/7_LLaMA_Code/LLaMATrainer.py`

## Scope / notes
- Generation only — no change to training, the loss computation, or the scorer. The scorer
  already treats unparseable predictions as empty, so this changes prediction *quality*, not the
  metric code.
- The rest of #4 (free-form output after ~10 steps) is expected under-training rather than a bug;
  the model needs to train toward convergence before the output format settles. This PR addresses
  the genuine eval-loop issue and clears the warning.

## Testing
- Both files byte-compile (`python -m py_compile`).
- Not run through a full fine-tuning/eval cycle here; a live eval run on a saved checkpoint is the
  recommended confirmation.

