### PR TITLE
Make guideline generation runnable end-to-end

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -346,15 +346,46 @@ respectively.
 
 **Note**: We’ve already the synethesized guidelines and available human guidelines in directory `guideline_generation/synthesize_guidelines/synthesized_guidelines`
 
-To generate the guidelines, please run the following command:
+To (re)generate the guidelines, or to generate them for a new dataset, run the pipeline below from
+the `guideline_generation` directory:
 ```bash
 cd guideline_generation
-python synthesize_guidelines/create_dictionaries.py --dataset_name <dataset_name>
-python prompting/prompt_llms.py #generates guidelines P, PN, PS
-python prompting/prompt_llm_adv_guidelines.py #generates Int- guidelines
-cd .. # to navigate to home directory
+
+# (0) Credentials. Azure OpenAI is the default; pass --api_type openai for standard OpenAI.
+export OPENAI_API_KEY="<your key>"
+export AZURE_OPENAI_ENDPOINT="https://<your-resource>.openai.azure.com/"   # Azure only
+
+# (1) Convert TextEE processed data into the guideline "master" JSONL (the first hop).
+python utils/textee_to_master.py -d <dataset_name> -i <TextEE/processed_data> \
+    --split split1 --files train.json -o ./synthesize_guidelines/master_<dataset_name>.jsonl
+
+# (2) Build the per-event prompts from the master file.
+#     --neg_strategy sibling -> Guideline-PS, random -> Guideline-PN; add --examples_per_event 0 for
+#     positive-only Guideline-P. Negative sampling is seeded (--seed) for reproducibility.
+python synthesize_guidelines/synthesize_guidelines_w_neg_samples.py \
+    --master_file ./synthesize_guidelines/master_<dataset_name>.jsonl \
+    --dataset_name <prompt_set> --neg_strategy sibling --seed 1337 \
+    --output_dir ./synthesize_guidelines/prompts
+
+# (3) Generate the P / PN / PS guidelines from those prompts (add --dry_run to test without the API).
+python prompting/prompt_llms.py --dataset_name <prompt_set> \
+    --prompt_dir ./synthesize_guidelines/prompts \
+    --out_dir ./synthesize_guidelines/synthesized_guidelines/
+
+# (4) [Optional] Integrated variants (Guideline-PN-Int / PS-Int): build the consolidation prompts
+#     from the generated guidelines, then prompt the LLM with them.
+python synthesize_guidelines/synthesize_adv_guideline_PN.py \
+    --input_dir ./synthesize_guidelines/synthesized_guidelines/<prompt_set> \
+    --output_dir ./synthesize_guidelines/prompts/<prompt_set>_INT
+python prompting/prompt_llm_adv_guidelines.py --dataset_name <prompt_set>_INT \
+    --prompt_dir ./synthesize_guidelines/prompts \
+    --out_dir ./synthesize_guidelines/synthesized_guidelines/
+
+cd ..  # back to the repo root
 ```
-where, `<dataset_name>` refers to the dataset for which the guidelines need to be genrated (e.g., ace05-en), `<guideline_type>` refers to one of the 5 variants discussed above, i.e., one from Guideline-P (P), Guideline-PN (PN), Guideline-PS (PS), Guideline-PN-Int (PNI) or Guideline-PS-Int (PSI).
+where `<dataset_name>` is a TextEE dataset (e.g. `ace05-en`) and `<prompt_set>` is any name you pick
+for the generated prompt/guideline subdir (e.g. `ace05_PS`). Pass `--dry_run` to the two `prompt_*`
+scripts to validate the full pipeline offline (no API key or spend).
 ### 📘 Guideline File Format
 After above code execution, the guidelines will be stored in the file `<output_file>`. Please make sure that your guideline file looks like:
 

--- a/guideline_generation/prompting/prompt_llm_adv_guidelines.py
+++ b/guideline_generation/prompting/prompt_llm_adv_guidelines.py
@@ -38,10 +38,34 @@ parser.add_argument("-f", "--freq_pen", default = 0.0)
 parser.add_argument("-n", "--pres_pen", default=0.0)
 parser.add_argument("-o", "--out_dir", default="./../synthesize_guidelines/synthesized_guidelines/")
 parser.add_argument("-d", "--dataset_name", default="richere-en")
+# Backend / credentials (kept backward compatible: Azure remains the default).
+parser.add_argument("--api_type", choices=["azure", "openai"], default="azure",
+                    help="LLM backend: Azure OpenAI (default) or standard OpenAI.")
+parser.add_argument("--azure_endpoint", default=os.environ.get("AZURE_OPENAI_ENDPOINT"),
+                    help="Azure endpoint URL (or set AZURE_OPENAI_ENDPOINT). Overrides the built-in default.")
+parser.add_argument("--azure_deployment", default=os.environ.get("AZURE_OPENAI_DEPLOYMENT"),
+                    help="Azure deployment name (defaults to the model name in MODEL_MAP).")
+parser.add_argument("--api_version", default=os.environ.get("AZURE_OPENAI_API_VERSION"),
+                    help="Azure API version (defaults to the value in MODEL_MAP).")
+parser.add_argument("--event_arg_ontology", default=None,
+                    help="Optional path to the ontology JSON (unused by the consolidation step; kept for parity).")
+parser.add_argument("--dry_run", action="store_true",
+                    help="Validate the pipeline (prompt loading, parsing, file writing) without calling the API.")
 
 MODEL_MAP = {
     "gpt-4o": {"name": "gpt-4o-2024-05-13", "endpoint": "https://azure-openai-api-eastus2.openai.azure.com/", "api_version": "2024-04-01-preview"}
 }
+
+# Well-formed sample response used by --dry_run. The consolidation step emits a single
+# string per field (not a list), so the canned response matches that shape.
+DRY_RUN_RESPONSE = """Here is the consolidated guideline:
+```json
+{
+  "Event Definition": "Consolidated advanced definition for the event type.",
+  "Arguments Definitions": {"mention": "The text span that triggers the event.", "entity": "Consolidated definition for entity.", "place": "Consolidated definition for place."}
+}
+```
+"""
 
 
 # guidelines = json.load(open("./../synthesize_guidelines/fewevent_event_dataclasses.json"))
@@ -192,17 +216,20 @@ def get_response(model, prompt, args, client, event_name, guidelines, dataset_na
                 time.sleep(cooldown_period)
                 total_tokens_used = 0  # Reset after cooldown
 
-            # Send the request to the OpenAI API
-            response = client.chat.completions.create(
-                model=model,
-                messages=[{"role": "user", "content": prompt}],
-                temperature=args.temperature,
-                max_tokens=args.max_tokens,
-                top_p=args.top_p,
-                frequency_penalty=args.freq_pen,
-                presence_penalty=args.pres_pen
-            )
-            response_content = response.choices[0].message.content
+            # Send the request to the OpenAI API (or use a canned response in dry-run mode)
+            if getattr(args, "dry_run", False):
+                response_content = DRY_RUN_RESPONSE
+            else:
+                response = client.chat.completions.create(
+                    model=model,
+                    messages=[{"role": "user", "content": prompt}],
+                    temperature=args.temperature,
+                    max_tokens=args.max_tokens,
+                    top_p=args.top_p,
+                    frequency_penalty=args.freq_pen,
+                    presence_penalty=args.pres_pen
+                )
+                response_content = response.choices[0].message.content
             
             # Save logs
             os.makedirs(f"./logs/{dataset_name}", exist_ok=True)
@@ -233,7 +260,8 @@ def get_response(model, prompt, args, client, event_name, guidelines, dataset_na
                 time.sleep(cooldown_period)
 
             # Add a delay between successful requests
-            time.sleep(delay)
+            if not getattr(args, "dry_run", False):
+                time.sleep(delay)
             return largest_json
 
         except OpenAIError as e:
@@ -250,18 +278,39 @@ if __name__ == "__main__":
     args = parser.parse_args()
     dataset_name = args.dataset_name
     args.out_dir = os.path.join(args.out_dir, dataset_name)
-    guidelines = json.load(open(dataset_mapper[dataset_name]["event_arg_ontology"]))
-    openai_key = os.environ.get("OPENAI_API_KEY")
-    if(openai_key is None):
-        os.environ["OPENAI_API_KEY"] = openai_key = getpass.getpass(prompt='Enter your OPENAI_API_KEY: ')
-    client = AzureOpenAI(
-    api_key=openai_key,
-    api_version=MODEL_MAP[args.llm]["api_version"],
-    azure_endpoint=MODEL_MAP[args.llm]["endpoint"],
-    azure_deployment=MODEL_MAP[args.llm]["name"]
-    )
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    # Ontology is not used by the consolidation step; load it only if explicitly provided.
+    ontology_path = args.event_arg_ontology
+    if ontology_path is None and dataset_name in dataset_mapper:
+        ontology_path = dataset_mapper[dataset_name].get("event_arg_ontology")
+    guidelines = json.load(open(ontology_path)) if ontology_path and os.path.exists(ontology_path) else {}
+
+    model_name = MODEL_MAP[args.llm]["name"]
+    client = None
+    if not args.dry_run:
+        openai_key = os.environ.get("OPENAI_API_KEY")
+        if(openai_key is None):
+            os.environ["OPENAI_API_KEY"] = openai_key = getpass.getpass(prompt='Enter your OPENAI_API_KEY: ')
+        if args.api_type == "azure":
+            client = AzureOpenAI(
+                api_key=openai_key,
+                api_version=args.api_version or MODEL_MAP[args.llm]["api_version"],
+                azure_endpoint=args.azure_endpoint or MODEL_MAP[args.llm]["endpoint"],
+                azure_deployment=args.azure_deployment or model_name,
+            )
+        else:
+            from openai import OpenAI
+            client = OpenAI(api_key=openai_key)
+    else:
+        print("[dry_run] Skipping API client creation; using canned responses.")
+
     prompt_files = glob(os.path.join(os.path.join(args.prompt_dir, dataset_name), "*.txt"))
-    existing_files = [os.path.split(ff)[-1].replace("prompt_", "").replace(".json", "") for ff in glob(f"/scratch/spati/tmp/LLaMA-Events_w_neg_samples/synthesize_guidelines/synthesized_guidelines/{dataset_name}/*.json")]
+    if not prompt_files:
+        print(f"[warn] No prompt .txt files found under {os.path.join(args.prompt_dir, dataset_name)}. "
+              f"Check --prompt_dir and --dataset_name (e.g. ACE_15random_adv_guidelines).")
+    # Skip events already generated in the output directory (resumable).
+    existing_files = [os.path.split(ff)[-1].replace("prompt_", "").replace(".json", "") for ff in glob(os.path.join(args.out_dir, "*.json"))]
     # print(existing_files)
     for prompt_file in tqdm(prompt_files, total = len(prompt_files), desc = "Prompting ..."):
         event_name = os.path.split(prompt_file)[-1].replace("prompt_", "").replace(".txt", "")
@@ -277,11 +326,12 @@ if __name__ == "__main__":
         # xx
         prompt = "".join([lines for lines in open(prompt_file)])
         #model, prompt, args, client, event_name, guidelines, dataset_name):
-        get_response(args.llm, prompt, args, client, prompt_file, guidelines, dataset_name)
+        get_response(model_name, prompt, args, client, prompt_file, guidelines, dataset_name)
         # break
 
         # Add a delay to avoid hitting the rate limit
-        time.sleep(2)
+        if not args.dry_run:
+            time.sleep(2)
 
 
 

--- a/guideline_generation/prompting/prompt_llms.py
+++ b/guideline_generation/prompting/prompt_llms.py
@@ -38,10 +38,38 @@ parser.add_argument("-f", "--freq_pen", default = 0.0)
 parser.add_argument("-n", "--pres_pen", default=0.0)
 parser.add_argument("-o", "--out_dir", default="./../synthesize_guidelines/synthesized_guidelines/")
 parser.add_argument("-d", "--dataset_name", default="richere-en")
+# Backend / credentials (kept backward compatible: Azure remains the default).
+parser.add_argument("--api_type", choices=["azure", "openai"], default="azure",
+                    help="LLM backend: Azure OpenAI (default) or standard OpenAI.")
+parser.add_argument("--azure_endpoint", default=os.environ.get("AZURE_OPENAI_ENDPOINT"),
+                    help="Azure endpoint URL (or set AZURE_OPENAI_ENDPOINT). Overrides the built-in default.")
+parser.add_argument("--azure_deployment", default=os.environ.get("AZURE_OPENAI_DEPLOYMENT"),
+                    help="Azure deployment name (defaults to the model name in MODEL_MAP).")
+parser.add_argument("--api_version", default=os.environ.get("AZURE_OPENAI_API_VERSION"),
+                    help="Azure API version (defaults to the value in MODEL_MAP).")
+# Optional: only used to source the 'mention' description; a default is used if omitted.
+parser.add_argument("--event_arg_ontology", default=None,
+                    help="Optional path to Master_event_dataclasses_<dataset>.json. If omitted, "
+                         "a default 'mention' description is used and no scratch path is needed.")
+parser.add_argument("--dry_run", action="store_true",
+                    help="Validate the pipeline (prompt loading, parsing, file writing) without calling the API.")
 
 MODEL_MAP = {
     "gpt-4o": {"name": "gpt-4o-2024-05-13", "endpoint": "https://azure-openai-api-eastus2.openai.azure.com/", "api_version": "2024-04-01-preview"}
 }
+
+# Canonical mention description used across all released guidelines; fallback when no ontology is provided.
+DEFAULT_MENTION = "The text span that triggers the event."
+
+# Well-formed sample response used by --dry_run so the full parse/write path can be exercised offline.
+DRY_RUN_RESPONSE = """Here are the guidelines:
+```json
+{
+  "Event Definition": ["Definition 1", "Definition 2", "Definition 3", "Definition 4", "Definition 5"],
+  "Arguments Definitions": {"entity": ["e1", "e2", "e3", "e4", "e5"], "place": ["p1", "p2", "p3", "p4", "p5"]}
+}
+```
+"""
 
 
 # guidelines = json.load(open("./../synthesize_guidelines/fewevent_event_dataclasses.json"))
@@ -54,7 +82,11 @@ def parse_response(response, event_name, guidelines):
     response = response if(type(response) == type({})) else ast.literal_eval(response)
     # print(response)
     event_name = event_name.replace("prompt_", "").strip()
-    return_dict = {event_name:{"description":None}, "attributes":{"mention": guidelines[event_name]["attributes"]["mention"]}}
+    try:
+        mention = guidelines[event_name]["attributes"]["mention"]
+    except (KeyError, TypeError):
+        mention = DEFAULT_MENTION
+    return_dict = {event_name:{"description":None}, "attributes":{"mention": mention}}
     # print("<<<", return_dict)
     # print(">>>", type(response))
     return_dict[event_name]["description"] = response["Event Definition"]
@@ -88,17 +120,20 @@ def get_response(model, prompt, args, client, event_name, guidelines, dataset_na
                 time.sleep(cooldown_period)
                 total_tokens_used = 0  # Reset after cooldown
 
-            # Send the request to the OpenAI API
-            response = client.chat.completions.create(
-                model=model,
-                messages=[{"role": "user", "content": prompt}],
-                temperature=args.temperature,
-                max_tokens=args.max_tokens,
-                top_p=args.top_p,
-                frequency_penalty=args.freq_pen,
-                presence_penalty=args.pres_pen
-            )
-            response = response.choices[0].message.content
+            # Send the request to the OpenAI API (or use a canned response in dry-run mode)
+            if getattr(args, "dry_run", False):
+                response = DRY_RUN_RESPONSE
+            else:
+                response = client.chat.completions.create(
+                    model=model,
+                    messages=[{"role": "user", "content": prompt}],
+                    temperature=args.temperature,
+                    max_tokens=args.max_tokens,
+                    top_p=args.top_p,
+                    frequency_penalty=args.freq_pen,
+                    presence_penalty=args.pres_pen
+                )
+                response = response.choices[0].message.content
             
             # Save logs
             os.makedirs(f"./logs/{dataset_name}", exist_ok=True)
@@ -129,7 +164,8 @@ def get_response(model, prompt, args, client, event_name, guidelines, dataset_na
                 time.sleep(cooldown_period)
 
             # Add a delay between successful requests
-            time.sleep(delay)
+            if not getattr(args, "dry_run", False):
+                time.sleep(delay)
             return largest_json
 
         except OpenAIError as e:
@@ -146,18 +182,45 @@ if __name__ == "__main__":
     args = parser.parse_args()
     dataset_name = args.dataset_name
     args.out_dir = os.path.join(args.out_dir, dataset_name)
-    guidelines = json.load(open(dataset_mapper[dataset_name]["event_arg_ontology"]))
-    openai_key = os.environ.get("OPENAI_API_KEY")
-    if(openai_key is None):
-        os.environ["OPENAI_API_KEY"] = openai_key = getpass.getpass(prompt='Enter your OPENAI_API_KEY: ')
-    client = AzureOpenAI(
-    api_key=openai_key,
-    api_version=MODEL_MAP[args.llm]["api_version"],
-    azure_endpoint=MODEL_MAP[args.llm]["endpoint"],
-    azure_deployment=MODEL_MAP[args.llm]["name"]
-    )
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    # Optional ontology: used only to source the per-event 'mention' description.
+    # Resolve from --event_arg_ontology, else the mapper (if present), else skip (a default is used).
+    ontology_path = args.event_arg_ontology
+    if ontology_path is None and dataset_name in dataset_mapper:
+        ontology_path = dataset_mapper[dataset_name].get("event_arg_ontology")
+    if ontology_path and os.path.exists(ontology_path):
+        guidelines = json.load(open(ontology_path))
+    else:
+        if ontology_path:
+            print(f"[warn] event_arg_ontology not found at '{ontology_path}'; using default 'mention' description.")
+        guidelines = {}
+
+    model_name = MODEL_MAP[args.llm]["name"]
+    client = None
+    if not args.dry_run:
+        openai_key = os.environ.get("OPENAI_API_KEY")
+        if(openai_key is None):
+            os.environ["OPENAI_API_KEY"] = openai_key = getpass.getpass(prompt='Enter your OPENAI_API_KEY: ')
+        if args.api_type == "azure":
+            client = AzureOpenAI(
+                api_key=openai_key,
+                api_version=args.api_version or MODEL_MAP[args.llm]["api_version"],
+                azure_endpoint=args.azure_endpoint or MODEL_MAP[args.llm]["endpoint"],
+                azure_deployment=args.azure_deployment or model_name,
+            )
+        else:
+            from openai import OpenAI
+            client = OpenAI(api_key=openai_key)
+    else:
+        print("[dry_run] Skipping API client creation; using canned responses.")
+
     prompt_files = glob(os.path.join(os.path.join(args.prompt_dir, dataset_name), "*.txt"))
-    existing_files = [os.path.split(ff)[-1].replace("prompt_", "").replace(".json", "") for ff in glob(f"/scratch/spati/tmp/LLaMA-Events_w_neg_samples/synthesize_guidelines/synthesized_guidelines/{dataset_name}/*.json")]
+    if not prompt_files:
+        print(f"[warn] No prompt .txt files found under {os.path.join(args.prompt_dir, dataset_name)}. "
+              f"Check --prompt_dir and --dataset_name (e.g. ACE_15random_examples).")
+    # Skip events already generated in the output directory (resumable).
+    existing_files = [os.path.split(ff)[-1].replace("prompt_", "").replace(".json", "") for ff in glob(os.path.join(args.out_dir, "*.json"))]
     # print(existing_files)
     for prompt_file in tqdm(prompt_files, total = len(prompt_files), desc = "Prompting ..."):
         event_name = os.path.split(prompt_file)[-1].replace("prompt_", "").replace(".txt", "")
@@ -173,11 +236,12 @@ if __name__ == "__main__":
         # xx
         prompt = "".join([lines for lines in open(prompt_file)])
         #model, prompt, args, client, event_name, guidelines, dataset_name):
-        get_response(args.llm, prompt, args, client, prompt_file, guidelines, dataset_name)
+        get_response(model_name, prompt, args, client, prompt_file, guidelines, dataset_name)
         # break
 
         # Add a delay to avoid hitting the rate limit
-        time.sleep(2)
+        if not args.dry_run:
+            time.sleep(2)
 
 
 

--- a/guideline_generation/synthesize_guidelines/synthesize_adv_guideline_PN.py
+++ b/guideline_generation/synthesize_guidelines/synthesize_adv_guideline_PN.py
@@ -84,16 +84,24 @@ def create_advanced_prompt(event_type, detailed_guidelines):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("-d", "--dataset_name", help="Dataset Name", default="richere-en")
+    parser.add_argument("-d", "--dataset_name", help="Dataset Name (used for mapper fallback)", default="richere-en")
+    parser.add_argument("--input_dir", default=None,
+                        help="Directory of generated P/PN/PS guideline JSONs to consolidate "
+                             "(e.g. ./synthesize_guidelines/synthesized_guidelines/<name>).")
+    parser.add_argument("--output_dir", default=None,
+                        help="Where to write the consolidation prompts adv_<event>.txt "
+                             "(e.g. ./synthesize_guidelines/prompts/<name>_adv_guidelines).")
     args = parser.parse_args()
 
-    # Get dataset-specific directories
+    # Resolve directories: explicit CLI flags take precedence over the (legacy) dataset_mapper.
     dataset_name = args.dataset_name
-    dataset_info = dataset_mapper[dataset_name]
-
-    # Input and output directories
-    input_dir = dataset_info["output_dir"]
-    output_dir = dataset_info["advanced_prompt_dir"]
+    dataset_info = dataset_mapper.get(dataset_name, {})
+    input_dir = args.input_dir or dataset_info.get("output_dir")
+    output_dir = args.output_dir or dataset_info.get("advanced_prompt_dir")
+    if not input_dir or not os.path.isdir(input_dir):
+        raise SystemExit(f"input_dir not found: {input_dir}. Pass --input_dir pointing at the generated P/PN/PS guidelines.")
+    if not output_dir:
+        raise SystemExit("output_dir not set. Pass --output_dir for the consolidation prompts.")
     os.makedirs(output_dir, exist_ok=True)
 
     # Process all JSON files in the input directory

--- a/guideline_generation/synthesize_guidelines/synthesize_guidelines_w_neg_samples.py
+++ b/guideline_generation/synthesize_guidelines/synthesize_guidelines_w_neg_samples.py
@@ -24,7 +24,25 @@ dataset_mapper = {
 }
 
 parser = argparse.ArgumentParser()
-parser.add_argument("-d", "--dataset_name", help="Dataset Name", default="richere-en")
+parser.add_argument("-d", "--dataset_name", help="Dataset Name (used for the output prompts/<dataset_name> subdir)", default="richere-en")
+# New-dataset mode: derive everything (event types, argument lists, positive/negative example
+# pools) from a single TextEE-style master JSONL, so no uncommitted def_file/ontology/example_dir
+# are required. Each line: {"text": ..., "event_mentions": {"<Event(Parent)>": {"results": [ {...} ]}}}.
+parser.add_argument("--master_file", default=None,
+                    help="Path to a TextEE-style master JSONL. If given, def_file/event_arg_ontology/"
+                         "example_dir are derived from it and are not needed.")
+# Explicit-paths mode (legacy): override the hardcoded dataset_mapper entries.
+parser.add_argument("--def_file", default=None, help="Override def_file path.")
+parser.add_argument("--event_arg_ontology", default=None,
+                    help="Override ontology path (optional; argument names are taken from def_file if absent).")
+parser.add_argument("--example_dir", default=None, help="Override per-event example_dir path.")
+parser.add_argument("--output_dir", default="prompts", help="Where prompt subdirs are written (default: ./prompts).")
+parser.add_argument("--neg_strategy", choices=["sibling", "random"], default="sibling",
+                    help="Negative sampling: 'sibling' (Guideline-PS) or 'random' across event types (Guideline-PN).")
+parser.add_argument("--num_negatives", type=int, default=10, help="Target number of negative examples.")
+parser.add_argument("--examples_per_event", type=int, default=1, help="Negative examples drawn per selected event type.")
+parser.add_argument("--max_samples", type=int, default=MAX_SAMPLES, help="Max positive examples per event type.")
+parser.add_argument("--seed", type=int, default=1337, help="Random seed (makes negative sampling reproducible).")
 
 
 PROMPT = """You are an expert in annotating NLP datasets for event extraction.Your task is to generate precise and detailed annotation guidelines for the event type [###Event_Type###]
@@ -321,92 +339,151 @@ def create_examples(event_type_dict, event_type, full_argument_list):
 #############################################################Guideline-PS#########################################################################################
 ############ This below is the function to add negative samples such that I add 1 examples each from only the sibling event types  ###################
 #############################################################################################################################################################
-def create_negative_examples(all_event_types, current_event_type, dataset_name, num_negatives, examples_per_event=1):
+def _load_event_examples(event_type, example_pools=None, example_dir=None):
+    """Return the example list for an event type from in-memory pools or from example_dir files."""
+    if example_pools is not None:
+        return list(example_pools.get(event_type, []))
+    file_path = f"{example_dir}/{event_type}.json"
+    try:
+        with open(file_path, 'r') as file:
+            return [json.loads(line) for line in file]
+    except FileNotFoundError:
+        print(f"Warning: File not found for event type {event_type} at {file_path}")
+        return []
+
+
+def create_negative_examples(all_event_types, current_event_type, num_negatives, examples_per_event=1,
+                             strategy="sibling", example_pools=None, example_dir=None):
     print("****" * 50)
-    print("Negative Examples")
+    print(f"Negative Examples (strategy={strategy})")
 
-    # Extract the superclass of the current event type
-    current_superclass = current_event_type.split('(')[-1].rstrip(')')
-    print(f"Superclass of current event type: {current_superclass}")
+    if strategy == "sibling":
+        # Guideline-PS: negatives are sibling event types sharing the same superclass.
+        current_superclass = current_event_type.split('(')[-1].rstrip(')')
+        candidate_event_types = [
+            et for et in all_event_types
+            if et != current_event_type and et != "None"
+            and et.split('(')[-1].rstrip(')') == current_superclass
+        ]
+        print(f"Sibling event types for negatives: {candidate_event_types}")
+    else:
+        # Guideline-PN: negatives are randomly drawn across all other event types.
+        candidate_event_types = [et for et in all_event_types if et != current_event_type and et != "None"]
 
-    # Filter sibling event types
-    sibling_event_types = [
-        et for et in all_event_types
-        if et != current_event_type and et.split('(')[-1].rstrip(')') == current_superclass
-    ]
-    print(f"Sibling event types for negatives: {sibling_event_types}")
-
-    # Randomly select up to 15 sibling event types
-    selected_event_types = random.sample(sibling_event_types, min(15, len(sibling_event_types)))
-    print(f"Randomly selected sibling event types for negatives: {selected_event_types}")
+    # Randomly select up to 15 event types (seeded in __main__ for reproducibility).
+    selected_event_types = random.sample(candidate_event_types, min(15, len(candidate_event_types)))
+    print(f"Selected event types for negatives: {selected_event_types}")
 
     negative_examples = []
 
-    # Function to count attributes in an example's results section
     def count_attributes_in_results(example, event_type):
         results = example['event_mentions'][event_type]['results']
         return max(len(result.keys()) for result in results) if results else 0
 
-    # Fetch examples from the selected sibling event types
     for event_type in selected_event_types:
-        file_path = f"{dataset_mapper[dataset_name]['example_dir']}/{event_type}.json"
-        try:
-            with open(file_path, 'r') as file:
-                examples = [json.loads(line) for line in file]
-
-                # Sort examples by the number of attributes in the results section
-                examples_sorted = sorted(
-                    examples,
-                    key=lambda ex: count_attributes_in_results(ex, event_type),
-                    reverse=True
-                )
-
-                print(f"Loaded and sorted {len(examples_sorted)} examples from {event_type}")
-
-                # Select up to `examples_per_event` examples per sibling event type
-                num_to_select = min(examples_per_event, len(examples_sorted))
-                selected_samples = examples_sorted[:num_to_select]
-                negative_examples.extend(selected_samples)
-
-                print(f"Selected {len(selected_samples)} negatives from {event_type}")
-                for sample in selected_samples:
-                    attr_count = count_attributes_in_results(sample, event_type)
-                    print(f"Example with {attr_count} attributes: {sample['text']}")
-        except FileNotFoundError:
-            print(f"Warning: File not found for event type {event_type} at {file_path}")
-
-    print("Negative examples list:")
-    print(negative_examples)  # Directly print the list of all negative examples
+        examples = _load_event_examples(event_type, example_pools=example_pools, example_dir=example_dir)
+        if not examples:
+            continue
+        examples_sorted = sorted(
+            examples,
+            key=lambda ex: count_attributes_in_results(ex, event_type),
+            reverse=True
+        )
+        num_to_select = min(examples_per_event, len(examples_sorted))
+        negative_examples.extend(examples_sorted[:num_to_select])
 
     print("****" * 50)
     return negative_examples
 
+def _display_name(event_type):
+    name = event_type.split("(")[0]
+    parent = event_type[event_type.find("(") + 1:event_type.find(")")] if "(" in event_type else ""
+    spaced = re.sub(r"(\w)([A-Z])", r"\1 \2", name)
+    parent_spaced = re.sub(r"(\w)([A-Z])", r"\1 \2", parent)
+    return f"Event Type: {spaced}\nParent Event Type: {parent_spaced}"
+
+
+def build_from_master(master_file):
+    """Derive (def-like event_type_dict, ontology-like all_guidelines, per-event example_pools)
+    from a single TextEE-style master JSONL, so no separate def_file/ontology/example_dir are needed."""
+    event_type_dict, example_pools, all_guidelines = {}, {}, {}
+    with open(master_file) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            jsn = json.loads(line)
+            for event_type, payload in jsn.get("event_mentions", {}).items():
+                if event_type == "None":
+                    continue
+                example_pools.setdefault(event_type, []).append(jsn)
+                entry = event_type_dict.setdefault(event_type, {"DisplayName": _display_name(event_type), "Arguments": set()})
+                for result in payload.get("results", []):
+                    for k in result:
+                        if k != "mention":
+                            entry["Arguments"].add(k)
+    for et, entry in event_type_dict.items():
+        entry["Arguments"] = sorted(entry["Arguments"])
+        all_guidelines[et] = {"attributes": {"mention": ""}}
+        for a in entry["Arguments"]:
+            all_guidelines[et]["attributes"][a] = ""
+    return event_type_dict, all_guidelines, example_pools
+
+
 if __name__ == "__main__":
     args = parser.parse_args()
+    random.seed(args.seed)
+    MAX_SAMPLES = args.max_samples  # used by create_examples (module global)
     dataset_name = args.dataset_name
-    #this file has key value pairs of event and attributes
-    all_guidelines = json.load(open(dataset_mapper[dataset_name]["event_arg_ontology"]))
-    with open(dataset_mapper[dataset_name]["def_file"]) as f:
-        event_type_dict = json.load(f)
+
+    example_pools = None
+    example_dir = None
+    if args.master_file:
+        event_type_dict, all_guidelines, example_pools = build_from_master(args.master_file)
+    else:
+        entry = dataset_mapper.get(dataset_name, {})
+        def_file = args.def_file or entry.get("def_file")
+        ontology_path = args.event_arg_ontology or entry.get("event_arg_ontology")
+        example_dir = args.example_dir or entry.get("example_dir")
+        if not def_file or not os.path.exists(def_file):
+            raise SystemExit(f"def_file not found: {def_file}. Pass --master_file (recommended) or --def_file.")
+        with open(def_file) as f:
+            event_type_dict = json.load(f)
+        if ontology_path and os.path.exists(ontology_path):
+            all_guidelines = json.load(open(ontology_path))
+        else:
+            # Ontology only contributes argument names; derive them from def_file when it is absent.
+            all_guidelines = {}
+            for et, e in event_type_dict.items():
+                if et == "None":
+                    continue
+                all_guidelines[et] = {"attributes": {"mention": ""}}
+                for a in e.get("Arguments", []):
+                    if a != "mention":
+                        all_guidelines[et]["attributes"][a] = ""
 
     all_event_types = list(event_type_dict.keys())
+    out_base = os.path.join(args.output_dir, dataset_name)
+    os.makedirs(out_base, exist_ok=True)
 
     for event_type in event_type_dict:
-        print("event_type")
-        print(event_type)
         if event_type == "None":
             continue
         full_argument_list = event_type_dict[event_type]["Arguments"]
-        # print(full_argument_list)
-        # xx
-        examples = create_examples([json.loads(x) for x in open(f"{dataset_mapper[dataset_name]['example_dir']}/{event_type}.json")], event_type, full_argument_list)
-        # negative_examples = create_negative_examples(all_event_types, event_type, dataset_name, 10)  # Example with num_negatives set to 10
-        negative_examples = create_negative_examples(all_event_types,event_type,dataset_name,num_negatives=10,examples_per_event=1)
-        # prompt = create_prompt(event_type, examples, event_type_dict[event_type]["DisplayName"], all_guidelines)
-        prompt = create_prompt(event_type,positive_examples=examples, negative_examples=negative_examples,display_name=event_type_dict[event_type]["DisplayName"], all_guidelines=all_guidelines)
-        os.makedirs(f"prompts/{dataset_name}", exist_ok=True)
-        with open(f"prompts/{dataset_name}/prompt_" + event_type+".txt", "w") as f:
+        if example_pools is not None:
+            positive_pool = example_pools.get(event_type, [])
+        else:
+            positive_pool = _load_event_examples(event_type, example_dir=example_dir)
+        examples = create_examples(positive_pool, event_type, full_argument_list)
+        negative_examples = create_negative_examples(
+            all_event_types, event_type,
+            num_negatives=args.num_negatives, examples_per_event=args.examples_per_event,
+            strategy=args.neg_strategy, example_pools=example_pools, example_dir=example_dir,
+        )
+        prompt = create_prompt(event_type, positive_examples=examples, negative_examples=negative_examples,
+                               display_name=event_type_dict[event_type].get("DisplayName", ""),
+                               all_guidelines=all_guidelines)
+        with open(os.path.join(out_base, "prompt_" + event_type + ".txt"), "w") as f:
             f.write(prompt)
-        # print(f"Covered event type {event_type} with ")
-        # print("-*"*100)
-    # print(event_type_dict)
+        print(f"Wrote prompt for {event_type}")
+    print(f"Done. {sum(1 for et in event_type_dict if et != 'None')} prompts written to {out_base}/")

--- a/guideline_generation/utils/textee_to_master.py
+++ b/guideline_generation/utils/textee_to_master.py
@@ -1,0 +1,87 @@
+"""
+TextEE -> master JSONL converter (the "first hop" for guideline generation).
+
+Reads TextEE `processed_data/<dataset_name>/<split>/<file>.json` (one JSON object per line)
+and emits the master JSONL consumed by
+`synthesize_guidelines/synthesize_guidelines_w_neg_samples.py --master_file ...`.
+
+Output: one line per (sentence, event_type) so each line carries a single event type, matching
+the convention the downstream builder/scorers assume:
+
+    {"text": "...", "event_mentions": {"Die(LifeEvent)": {"results": [
+        {"mention": "killed", "victim": ["people"], "place": ["town"]}
+    ]}}}
+
+Event-type names are normalized with the repo's own `clean_event_name`, and argument roles are
+lowercased with '-'/'.' replaced (matching `generate_schema.py`) so the names line up everywhere.
+"""
+import argparse
+import json
+import os
+import sys
+
+# Reuse the repo's canonical event-name normalization (and schema_splitters).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from utils import clean_event_name, schema_splitters  # noqa: E402
+
+
+def _norm_role(role):
+    return role.lower().replace("-", "_").replace(".", "_")
+
+
+def convert_sentence(sent, dataset_name):
+    """Return {event_type: {"results": [ {mention, role: [spans]}, ... ]}} for one TextEE sentence."""
+    grouped = {}
+    for ev in sent.get("event_mentions", []):
+        event_type = clean_event_name(ev["event_type"], dataset_name)
+        trigger = ev.get("trigger", {})
+        mention = trigger.get("text", "") if isinstance(trigger, dict) else str(trigger)
+        result = {"mention": mention}
+        for arg in ev.get("arguments", []):
+            role = _norm_role(arg["role"])
+            span = arg.get("text", arg.get("mention", ""))
+            result.setdefault(role, []).append(span)
+        grouped.setdefault(event_type, {"results": []})["results"].append(result)
+    return grouped
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert TextEE processed data to the guideline master JSONL.")
+    parser.add_argument("-i", "--dataset_directory", default="./../../TextEE/processed_data",
+                        help="Root of TextEE processed_data.")
+    parser.add_argument("-d", "--dataset_name", required=True,
+                        help=f"Dataset name; must be a key in schema_splitters ({', '.join(schema_splitters)}).")
+    parser.add_argument("--split", default="split1", help="Split subdir (default: split1).")
+    parser.add_argument("--files", nargs="+", default=["train.json"],
+                        help="Which split files to include (e.g. train.json dev.json).")
+    parser.add_argument("-o", "--output", required=True, help="Output master JSONL path.")
+    args = parser.parse_args()
+
+    if args.dataset_name not in schema_splitters:
+        raise SystemExit(f"Unknown dataset_name '{args.dataset_name}'. Known: {list(schema_splitters)}")
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.output)), exist_ok=True)
+    n_sent, n_lines = 0, 0
+    with open(args.output, "w") as out:
+        for fname in args.files:
+            path = os.path.join(args.dataset_directory, args.dataset_name, args.split, fname)
+            if not os.path.exists(path):
+                print(f"[warn] missing TextEE file: {path}")
+                continue
+            for line in open(path):
+                line = line.strip()
+                if not line:
+                    continue
+                sent = json.loads(line)
+                n_sent += 1
+                grouped = convert_sentence(sent, args.dataset_name)
+                # Emit one line per event type so each carries a single event type.
+                for event_type, payload in grouped.items():
+                    out.write(json.dumps({"text": sent.get("text", ""),
+                                          "event_mentions": {event_type: payload}}) + "\n")
+                    n_lines += 1
+    print(f"Read {n_sent} sentences -> wrote {n_lines} master lines to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Makes the guideline-generation pipeline runnable end-to-end. Previously it depended on hardcoded
`/scratch` paths and a private Azure endpoint, so it could not run outside the authors' machine.
Every stage now runs from committed assets or a user's own data.

## Changes
- **`utils/textee_to_master.py` (new):** converts TextEE `processed_data` into the master JSONL the
  prompt builder consumes (reuses the repo's `clean_event_name`; one event type per line). This is
  the previously-missing first hop.
- **`synthesize_guidelines_w_neg_samples.py`:** add `--master_file` mode (derives event types,
  argument lists, and positive/negative example pools internally — no separate
  def_file/ontology/example_dir needed); keep an explicit-paths mode with optional ontology;
  support `--neg_strategy sibling|random` (PS/PN); seed negative sampling (`--seed`) for
  reproducibility.
- **`prompt_llms.py` / `prompt_llm_adv_guidelines.py`:** remove `/scratch` dependencies, make the
  ontology optional, make the backend configurable (Azure default, `--api_type openai`), resume
  from the real `--out_dir`, and add `--dry_run` to validate offline without an API key.
- **`synthesize_adv_guideline_PN.py`:** parameterize `--input_dir`/`--output_dir` for the
  Integrated (Int) consolidation prompts.
- **`ReadMe.md`:** update Step 2 with the corrected, complete generation pipeline.

## Testing
- Full pipeline validated on synthetic data (TextEE → master → prompts → P/PN/PS → Int → guidelines).
- `--dry_run` covers the LLM-calling stages offline; data-transform stages run for real.
- Negative sampling confirmed reproducible across runs with a fixed `--seed`.

